### PR TITLE
<< Click to Read >>

### DIFF
--- a/Components/Debug/Handlers/Controllers/ExceptionController.php
+++ b/Components/Debug/Handlers/Controllers/ExceptionController.php
@@ -29,7 +29,6 @@ class ExceptionController extends AbstractController {
      * Exception Handler Development Action
      */
     final public function development() {
-
         $this -> trigger( 'exception/development' );
     }
 
@@ -37,7 +36,6 @@ class ExceptionController extends AbstractController {
      * Exception Handler Production Action
      */
     final public function production() {
-
         $this -> trigger( 'exception/production' );
     }
 
@@ -61,7 +59,7 @@ class ExceptionController extends AbstractController {
 
             restore_exception_handler();
 
-            throw new \Next\Components\Debug( $e -> getMessage() );
+            throw new \Next\Components\Debug\Exception( $e -> getMessage() );
         }
     }
 }

--- a/Components/Debug/Handlers/Views/error/status/code500.phtml
+++ b/Components/Debug/Handlers/Views/error/status/code500.phtml
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+<title>Next Framework :: 500 INternal Server Error</title>
+
+</head>
+
+<body>
+
+<h1>Sorry! We're Fucked!</h1>
+
+</body>
+</html>

--- a/Components/Debug/Handlers/Views/exception/development.phtml
+++ b/Components/Debug/Handlers/Views/exception/development.phtml
@@ -26,7 +26,7 @@ a:hover {
 }
 
 body {
-    background-color: #141414;
+    background-color: #141414 !important;
     color: #2C2C2C;
     font: 12px Verdana;
     text-align: center;

--- a/Controller/Dispatcher/Standard.php
+++ b/Controller/Dispatcher/Standard.php
@@ -5,7 +5,7 @@ namespace Next\Controller\Dispatcher;
 use Next\Controller\ControllerException;    # Controller Exception Class
 use Next\View\ViewException;                # View Exception Class
 use Next\Application\Application;           # Application Interface
-use Next\Components\Exception\Handlers;     # Exceptions Handlers
+use Next\Components\Debug\Handlers;     # Exceptions Handlers
 
 /**
  * Standard Controller Dispatcher Class

--- a/DB/Query/Builder.php
+++ b/DB/Query/Builder.php
@@ -279,7 +279,7 @@ class Builder extends Object implements Query {
             self::SQL_WHERE         => array(),
             self::SQL_GROUP_BY      => FALSE,
             self::SQL_ORDER_BY      => FALSE,
-            self::SQL_LIMIT         => array( 0, 10 ),
+            self::SQL_LIMIT         => NULL,
             self::SQL_HAVING        => array(),
             self::SQL_UNION         => NULL
         );
@@ -516,8 +516,11 @@ class Builder extends Object implements Query {
 
         if( array_key_exists( self::SQL_LIMIT, self::$parts ) ) {
 
-            if( self::$parts[ self::SQL_LIMIT ] ) {
-                $clauses .= $this -> renderer -> limit( self::$parts[ self::SQL_LIMIT ] );
+            if( self::$parts[ self::SQL_LIMIT ] !== NULL ) {
+
+                if( self::$parts[ self::SQL_LIMIT ] ) {
+                    $clauses .= $this -> renderer -> limit( self::$parts[ self::SQL_LIMIT ] );
+                }
             }
         }
 

--- a/File/Tools.php
+++ b/File/Tools.php
@@ -33,7 +33,16 @@ class Tools {
      *   Cleaned and fixed path
      */
     public static function cleanAndInvertPath( $path ) {
-        return str_replace( '\\', '/', trim( $path, '/\\' ) );
+
+        // Clean boundary spaces
+
+        $path = trim( $path );
+
+        // Remove trailing slash
+
+        $path = rtrim( $path, '/\\' );
+
+        return str_replace( '\\', '/', $path );
     }
 
     /**

--- a/HTTP/Headers/AbstractHeaders.php
+++ b/HTTP/Headers/AbstractHeaders.php
@@ -219,7 +219,19 @@ abstract class AbstractHeaders extends Object {
 
             $header = strtolower( str_replace( 'HTTP_', '', $header ) );
 
-            $header = ucfirst( preg_replace( '/(-|_)(\w)/e', "strtoupper( '\\2' )", $header ) );
+            $header = ucfirst(
+
+                preg_replace_callback(
+
+                    '/(-|_)(\w)/',
+
+                    function( $matches ) {
+                        return strtoupper( $matches[1]);
+                    },
+
+                    $header
+                )
+            );
 
             // Checking if its a known Header Field
 

--- a/HTTP/Request.php
+++ b/HTTP/Request.php
@@ -284,7 +284,7 @@ class Request extends Object {
 
             // Default Request Headers. Internal Requests only.
 
-            if( defined( 'TURBO_MODE' ) && TURBO_MODE === FALSE ) $this -> addDefaultHeaders();
+            if( defined( 'TURBO_MODE' ) && ! TURBO_MODE === TRUE ) $this -> addDefaultHeaders();
         }
     }
 

--- a/HTTP/Response.php
+++ b/HTTP/Response.php
@@ -853,13 +853,15 @@ class Response extends Object {
 
             echo $this -> body;
 
-            if( ob_get_length() ) { ob_end_flush(); }
-
             // Should we end the Execution Flow?
 
             if( $this -> shouldAbort ) {
                 exit;
             }
+
+            // If we shouldn't, let's flush the buffer
+
+            if( ob_get_length() ) { ob_end_flush(); }
         }
     }
 

--- a/View/CompositeQueue.php
+++ b/View/CompositeQueue.php
@@ -4,6 +4,7 @@ namespace Next\View;
 
 use Next\Components\Object;            # Object Class
 use Next\Components\Iterator\Lists;    # Lists Collection Class
+
 /**
  * Composite View Class
  *
@@ -41,7 +42,7 @@ class CompositeQueue extends Lists {
          *
          * Partial Views must implement View Interface
          */
-        if( ! $object instanceof View ) {
+        if( ! $object instanceof CompositeView ) {
 
             throw ViewException::invalidPartial( $object );
         }

--- a/View/CompositeView.php
+++ b/View/CompositeView.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Next\View;
+
+/**
+ * CompositeView Interface
+ *
+ * @author        Bruno Augusto
+ *
+ * @copyright     Copyright (c) 2010 Next Studios
+ * @license       http://creativecommons.org/licenses/by/3.0/   Attribution 3.0 Unported
+ */
+interface CompositeView {}

--- a/View/Standard.php
+++ b/View/Standard.php
@@ -478,7 +478,7 @@ class Standard extends Object implements View {
             throw ViewException::invalidSpec();
          }
 
-         $this -> _fileSpec = implode( '/', $pairs );
+         $this -> _fileSpec = $spec;
 
          return $this;
     }
@@ -557,7 +557,7 @@ class Standard extends Object implements View {
 
             // Creating a new Template Variable
 
-            $this -> _tplVars[ $tplVar ] =& $value;
+            $this -> _tplVars[ $tplVar ] = $value;
         }
 
         return $this;
@@ -621,7 +621,7 @@ class Standard extends Object implements View {
          *   var_dump() or even a ControllerException which was caught
          */
         if( ! $this -> _shouldRender || ob_get_length() != 0 ) {
-            return NULL;
+            return $response;
         }
 
         if( $search == FALSE && empty( $name ) ) {
@@ -980,17 +980,20 @@ class Standard extends Object implements View {
          * @internal
          * Finding Default SubPath
          *
-         * Default SubPath is built by removing:
+         * Default SubPath is built by removing from Controllers Name:
          *
          * - Application Directory,
          * - 'Controller' Keyword
          * - Controller ClassName
-         *
-         * from Controllers Name
          */
+
+        // Using substr() and strpos() instead of basename() due differences produced between Windows and Linux
+
+        $controllerBasename = substr( $controller, (int) strrpos( $controller, '\\' ) + 1 );
+
         $subpath = str_replace(
 
-                       array( $application, self::CONTROLLERS_KEYWORD, basename( $controller ) ),
+                       array( $application, self::CONTROLLERS_KEYWORD, $controllerBasename ),
 
                        '', $controller
                    );
@@ -1003,7 +1006,7 @@ class Standard extends Object implements View {
 
         // Cleaning Controller Class to find its "Real Name"
 
-        $controller = str_replace( 'Controller', '', basename( $controller ) );
+        $controller = str_replace( 'Controller', '', $controllerBasename );
 
         // Cleaning known Action suffixes
 


### PR DESCRIPTION
Next\Components\Debug\Handlers\Controllers\ExceptionController
- Fixed the namespace used in the try...catch() block which catches the
  possible Next\View\ViewException thrown

Next\Controller\Dispatcher\Standard
-Fixed imported namespace for Exception Handlers

Next\DB\Query\Builder
- Changed the default behavior of SQL LIMIT

Next\File\Tools
- Changed the default behavior of Tools::cleanAndInvertPath() to not
  remove the starting slash of *nix paths

Next\HTTP\Headers\AbstractHeaders
- Replaced a deprecated regex with PCRE evaluation modifer (e) with
  preg_replace_callback()

Next\HTTP\Request
- Fixed a condition to whether or not add default HTTP headers when
  TURBO MODE is enabled/disabled

Next\HTTP\Response
- Changed when the Response flow is aborted (if defined) helping
  integration with WordPress Themes

Next\View\CompositeQueue
- Changed the acceptance condition of Composite Views to an separate
  interface

Next\View\CompositeView
- Added a new interface for the feature described above

Next\View\Standard
- Fixed a wrong variable name in Standard::setFileSpec()
- Removed reference operator in Standard::assign() as part of future
  performance improvement
- Fixed Standard::render() to not break the execution flow if an output
  is already sent (ob_get_lengh() check) preventing premature abort when
  in a WordPress Theme
- Changed the way a classname is obtained in Standard::findFileBySpec()
  because of  differences produced by basename() function in *nix and
  Windows environments
- Minor doc-block changes, also in Standard::findFileBySpec()

Other changes
- Added new dummy template file for HTTP Response Code 500
